### PR TITLE
fix: Update dependencies and build with Java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,5 @@ jobs:
           when: always
       - store_test_results:
           path: ~/junit
+      - store_artifacts:
+          path: assembly/kar/target/opennms-pagerduty-plugin.kar

--- a/pom.xml
+++ b/pom.xml
@@ -10,20 +10,20 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>33.2.0-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jackson.version>2.11.1</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <java.version>11</java.version>
         <jaxrs.version>2.1.1</jaxrs.version>
         <jexl.version>3.1</jexl.version>
-        <junit.version>4.12</junit.version>
-        <karaf.version>4.3.6</karaf.version>
-        <log4j.version>2.13.3</log4j.version>
+        <junit.version>4.13.2</junit.version>
+        <karaf.version>4.3.10</karaf.version>
+        <log4j.version>2.23.1</log4j.version>
         <mockito.version>2.18.0</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>
-        <opennms.api.version>1.1.0</opennms.api.version>
+        <opennms.api.version>1.6.0</opennms.api.version>
         <osgi.version>7.0.0</osgi.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
@@ -112,7 +112,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>5.1.9</version>
                     <extensions>true</extensions>
                     <configuration>
                         <instructions>
@@ -132,22 +132,22 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.5.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <excludes>
                             <exclude>**/*IT.java</exclude>
@@ -177,7 +177,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce</id>


### PR DESCRIPTION
Bumped the dependencies to more modern versions, most importantly the OpenNMS Plugin API 1.6.0 and the same Karaf version as Horizon 33.0.3 has today.