### PR TITLE
eval-jexl shell command QoL improvements & additional alarm details

### DIFF
--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -28,5 +28,6 @@
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>
     </feature>
 </features>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl3</artifactId>

--- a/plugin/src/main/java/org/opennms/integrations/pagerduty/shell/JEXLEval.java
+++ b/plugin/src/main/java/org/opennms/integrations/pagerduty/shell/JEXLEval.java
@@ -28,43 +28,69 @@
 
 package org.opennms.integrations.pagerduty.shell;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.jexl3.JexlBuilder;
-import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.JexlEngine;
 import org.apache.commons.jexl3.JexlExpression;
-import org.apache.commons.jexl3.MapContext;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.opennms.integration.api.v1.dao.AlarmDao;
 import org.opennms.integration.api.v1.model.Alarm;
 import org.opennms.integrations.pagerduty.PagerDutyForwarder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.opennms.pagerduty.client.api.PDEvent;
 
 @Command(scope = "opennms-pagerduty", name = "eval-jexl", description = "Evaluate a JEXL expression")
 @Service
 public class JEXLEval implements Action {
 
+    private static final int SUMMARY_MAX_LENGTH = 1024;
     @Reference
     private AlarmDao alarmDao;
 
     @Argument(required = true)
     private String expression;
 
+    @Option(name = "-p", aliases = "--topayload", description = "Also convert matched alarms to JSON PagerDuty event payloads", required = false, multiValued = false)
+    Boolean toPayload = false;
+
+    @Option(name = "-c", aliases = "--count", description = "Only show the number of matching alarms, without alarm data", required = false, multiValued = false)
+    Boolean onlyCount = false;
+
     @Override
-    public Object execute() {
+    public Object execute() throws JsonProcessingException {
         JexlEngine jexl = new JexlBuilder().create();
         JexlExpression e = jexl.createExpression(expression);
 
         int numAlarmsProcessed = 0;
         boolean didMatchAtLeastOneAlarm = false;
+        int matchedAlarmCount = 0;
+
+        if (toPayload && onlyCount) {
+            System.out.println("Options '-p' and '-c' are mutually exclusive, ignoring '-p' ");
+        }
 
         for (Alarm alarm : alarmDao.getAlarms()) {
             numAlarmsProcessed++;
             boolean didMatch = PagerDutyForwarder.testAlarmAgainstExpression(e, alarm);
             if (didMatch) {
-                System.out.println("MATCHED: " + alarm);
+                if (!onlyCount) {
+                    System.out.println("MATCHED: " + alarm);
+                    if (toPayload) {
+                        ObjectMapper mapper = new ObjectMapper();
+                        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+                        PDEvent pdevent = new PDEvent();
+                        Object json = mapper.convertValue(PagerDutyForwarder.createPayload(alarm, pdevent), JsonNode.class);
+                        System.out.println("PagerDuty JSON Payload:\n " + mapper.writeValueAsString(json));
+                    }
+                }
+                matchedAlarmCount++;
                 didMatchAtLeastOneAlarm = true;
             }
         }
@@ -73,8 +99,9 @@ public class JEXLEval implements Action {
             System.out.println("No alarms present.");
         } else if (!didMatchAtLeastOneAlarm) {
             System.out.printf("No alarms matched (out of %d alarms.)\n", numAlarmsProcessed);
+        } else if (didMatchAtLeastOneAlarm && matchedAlarmCount > 0) {
+            System.out.printf("Matched %d alarms (out of %d alarms.)\n", matchedAlarmCount, numAlarmsProcessed);
         }
-
         return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <junit.version>4.13.2</junit.version>
         <karaf.version>4.3.10</karaf.version>
         <log4j.version>2.23.1</log4j.version>
-        <mockito.version>2.18.0</mockito.version>
+        <mockito.version>5.11.0</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <junit.version>4.13.2</junit.version>
         <karaf.version>4.3.10</karaf.version>
         <log4j.version>2.23.1</log4j.version>
-        <mockito.version>5.11.0</mockito.version>
+        <mockito.version>2.18.0</mockito.version>
         <okhttp.version>3.10.0</okhttp.version>
         <okhttp.bundle.version>3.10.0_2</okhttp.bundle.version>
         <okio.bundle.version>1.14.0_1</okio.bundle.version>


### PR DESCRIPTION
shell command QoL improvements:
- added '-p' to display the (pretty) JSON payload that will be send to PagerDuty - this also makes it easier to build matching expressions.
- added '-c' to display only the number of matching alarms

Also added additional fields from the alarm  to the `custom_detail` of the payload:
- the node label as `nodeLabel`
- the first IP address of the node as `node_ipAddress`
- the node categories as `node_categories`
- The entire alarm as  `alarm_data`

Supersedes #10 
closes #8 