### PR TITLE
Only forward alarms that match an expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ property-set routingKey "YOUR-INTEGRATION-KEY-HERE"
 config:update
 ```
 
-> Use the value of the "Integration Key" as the `routingKey` in the service integrations. By default, you will receive notifications for all alarms. Use a JEXL expression to filter the types of notifcations you receive. For example,`property-set jexlFilter 'alarm.reductionKey =~ ".*trigger.*"'` will forward only alarms with the label "trigger" to PagerDuty.    
+> Use the value of the "Integration Key" as the `routingKey` in the service integrations. Use a JEXL expression to filter the types of notifcations you receive. For example,`property-set jexlFilter 'alarm.reductionKey =~ ".*trigger.*"'` will forward only alarms with the label "trigger" to PagerDuty. No alarms will forward to PagerDuty until a JEXL expression is configured.   
 
 The plugin supports handling multiple services simultaneously - use a different `alias` for each of these when configuring.
 

--- a/plugin/src/main/java/org/opennms/integrations/pagerduty/PagerDutyForwarder.java
+++ b/plugin/src/main/java/org/opennms/integrations/pagerduty/PagerDutyForwarder.java
@@ -116,7 +116,8 @@ public class PagerDutyForwarder implements AlarmLifecycleListener, Closeable {
             return false;
         }
         if (jexlFilterExpression == null) {
-            return true;
+            LOG.info("No JEXL expression found, not evaluating alarm.");
+            return false;
         }
         return testAlarmAgainstExpression(jexlFilterExpression, alarm);
     }


### PR DESCRIPTION
Don't forward an alarm if there's no expression to evaluate.  Fixes #16 