### PR TITLE
Add workflow to make a release and improve readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 
-
 executors:
   build-executor:
     docker:
@@ -19,13 +18,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Compile source without tests
+          name: Compile source with tests
           command: |
-            mvn -DskipITs=true -DskipTests=true clean install
-      - run:
-          name: Run tests
-          command: |
-            mvn -DskipITs=false -DskipTests=false clean install test integration-test
+            make
       - run:
           name: Save test results
           command: |
@@ -33,7 +28,19 @@ jobs:
             find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/junit/ \;
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
           when: always
+      - run:
+          name: Collect artifacts
+          command: |
+            mkdir -p ~/artifacts/
+            find . -type f -regex ".*\/assembly\/kar\/target\/opennms-pagerduty-plugin-.*\.kar" -exec cp {} ~/artifacts/ \;
+      - run:
+          name: Create archive with checksums
+          command: |
+            cd ~/artifacts
+            shasum -a 256 -b opennms-pagerduty-plugin-*.kar > shasum256.txt
+            tar czf opennms-pagerduty-plugin.tar.gz opennms-pagerduty-plugin-*.kar shasum256.txt
+            shasum -a 256 -b opennms-pagerduty-plugin.tar.gz > opennms-pagerduty-plugin.sha256
       - store_test_results:
           path: ~/junit
       - store_artifacts:
-          path: assembly/kar/target/opennms-pagerduty-plugin.kar
+          path: ~/artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,115 @@
+.DEFAULT_GOAL := pagerduty-plugin
+
+SHELL               := /bin/bash -o nounset -o pipefail -o errexit
+VERSION             ?= $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+GIT_BRANCH          := $(shell git branch --show-current)
+GIT_SHORT_HASH      := $(shell git rev-parse --short HEAD)
+DATE                := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ") # Date format RFC3339
+JAVA_MAJOR_VERSION  := 11
+
+ARTIFACTS_DIR       := ./target
+RELEASE_VERSION     := UNSET.0.0
+RELEASE_BRANCH      := master
+MAJOR_VERSION       := $(shell echo $(RELEASE_VERSION) | cut -d. -f1)
+MINOR_VERSION       := $(shell echo $(RELEASE_VERSION) | cut -d. -f2)
+PATCH_VERSION       := $(shell echo $(RELEASE_VERSION) | cut -d. -f3)
+SNAPSHOT_VERSION    := $(MAJOR_VERSION).$(MINOR_VERSION).$(shell expr $(PATCH_VERSION) + 1)-SNAPSHOT
+RELEASE_LOG         := $(ARTIFACTS_DIR)/release.log
+OK                  := "[ 👍 ]"
+
+.PHONY help:
+help:
+	@echo ""
+	@echo "Build PagerDuty Plugin from source"
+	@echo "Goals:"
+	@echo "  help:              Show this help with explaining the build goals"
+	@echo "  pagerduty-plugin:  Compile, assemble and run test suite"
+	@echo "  clean:             Clean the build artifacts"
+	@echo "  release:           Create a release in the local repository, e.g. make release RELEASE_VERSION=x.y.z"
+	@echo ""
+
+.PHONY deps-build:
+deps-build:
+	@echo -n "👮‍♀️ Create artifact directory:   "
+	@mkdir -p $(ARTIFACTS_DIR)
+	@echo $(OK)
+	@echo -n "👮‍♀️ Check Java runtime:          "
+	@command -v java > /dev/null
+	@echo $(OK)
+	@echo -n "👮‍♀️ Check Java compiler:         "
+	@command -v javac > /dev/null
+	@echo $(OK)
+	@echo -n "👮‍♀️ Check Maven binary:          "
+	@command -v mvn > /dev/null
+	@echo $(OK)
+	@echo -n "👮‍♀️ Check Java version $(JAVA_MAJOR_VERSION):       "
+	@java --version | grep '$(JAVA_MAJOR_VERSION)\.[[:digit:]]*\.[[:digit:]]*' >/dev/null
+	@echo $(OK)
+	@echo -n "👮‍♀️ Validate Maven project:      "
+	@mvn validate > /dev/null
+	@echo $(OK)
+
+.PHONY pagerduty-plugin:
+pagerduty-plugin: deps-build
+	mvn install
+
+.PHONY clean:
+clean: deps-build
+	mvn clean
+
+.PHONY: release
+release: deps-build
+	@mkdir -p target
+	@echo ""
+	@echo "Release version:                $(RELEASE_VERSION)"
+	@echo "New snapshot version:           $(SNAPSHOT_VERSION)"
+	@echo "Git version tag:                v$(RELEASE_VERSION)"
+	@echo "Current branch:                 $(GIT_BRANCH)"
+	@echo "Release branch:                 $(RELEASE_BRANCH)"
+	@echo "Release log file:               $(RELEASE_LOG)"
+	@echo ""
+	@echo -n "👮‍♀️ Check release branch:        "
+	@if [ "$(GIT_BRANCH)" != "$(RELEASE_BRANCH)" ]; then echo "Releases are made from the $(RELEASE_BRANCH) branch, your branch is $(GIT_BRANCH)."; exit 1; fi
+	@echo "$(OK)"
+	@echo -n "👮‍♀️ Check uncommited changes     "
+	@if git status --porcelain | grep -q .; then echo "There are uncommited changes in your repository."; exit 1; fi
+	@echo "$(OK)"
+	@echo -n "👮‍♀️ Check branch in sync         "
+	@if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ]; then echo "$(RELEASE_BRANCH) branch not in sync with remote origin."; exit 1; fi
+	@echo "$(OK)"
+	@echo -n "👮‍♀️ Check release version:       "
+	@if [ "$(RELEASE_VERSION)" = "UNSET.0.0" ]; then echo "Set a release version, e.g. make release RELEASE_VERSION=1.0.0"; exit 1; fi
+	@echo "$(OK)"
+	@echo -n "👮‍♀️ Check version tag available: "
+	@if git rev-parse v$(RELEASE_VERSION) >$(RELEASE_LOG) 2>&1; then echo "Tag v$(RELEASE_VERSION) already exists"; exit 1; fi
+	@echo "$(OK)"
+	@echo -n "💅 Set Maven release version:   "
+	@mvn versions:set -DnewVersion=$(RELEASE_VERSION) >>$(RELEASE_LOG) 2>&1
+	@echo "$(OK)"
+	@echo -n "👮‍♀️ Validate build:              "
+	@$(MAKE) pagerduty-plugin >>$(RELEASE_LOG) 2>&1
+	@echo "$(OK)"
+	@echo -n "🎁 Git commit new release       "
+	@git commit --signoff -am "release: PagerDuty Plugin version $(RELEASE_VERSION)" >>$(RELEASE_LOG) 2>&1
+	@echo "$(OK)"
+	@echo -n "🦄 Set Git version tag:         "
+	@git tag -a "v$(RELEASE_VERSION)" -m "Release PagerDuty Plugin version $(RELEASE_VERSION)" >>$(RELEASE_LOG) 2>&1
+	@echo "$(OK)"
+	@echo -n "⬆️ Set Maven snapshot version:  "
+	@mvn versions:set -DnewVersion=$(SNAPSHOT_VERSION) >>$(RELEASE_LOG) 2>&1
+	@echo "$(OK)"
+	@echo -n "🎁 Git commit snapshot release: "
+	@git commit --signoff -am "release: PagerDuty Plugin version $(SNAPSHOT_VERSION)" >>$(RELEASE_LOG) 2>&1
+	@echo "$(OK)"
+	@echo ""
+	@echo "🦄 Congratulations! ✨"
+	@echo "You made a release in your local repository."
+	@echo "Publish the release by pushing the version tag"
+	@echo "and the new snapshot version to the remote repo"
+	@echo "with the following commands:"
+	@echo ""
+	@echo "  git push"
+	@echo "  git push origin v$(RELEASE_VERSION)"
+	@echo ""
+	@echo "Thank you for computing with us."
+	@echo ""

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![arch](assets/pd-alerts.png "PagerDuty Integration")
 
-## Overview
+## 🗺️ Overview
 
 This plugin allows you to create PagerDuty incidents that correspond to alarms in OpenNMS by integrating with the [Events API v2](https://developer.pagerduty.com/docs/events-api-v2/overview/).
 
@@ -15,64 +15,81 @@ OpenNMS alarms map naturally to incidents in PagerDuty:
 
 This plugin is compatible with OpenNMS Horizon 26.1.3 or higher.
 
-## Usage
+## 🕹️ Installation
 
-Download the plugin's .kar file into your OpenNMS deploy directory i.e.:
+Download the latest release with
+```shell
+mkdir pager-duty-plugin && cd pager-duty-plugin
+wget https://github.com/OpenNMS/opennms-pagerduty-plugin/releases/latest/download/opennms-pagerduty-plugin.tar.gz
 ```
-sudo wget https://github.com/OpenNMS/opennms-pagerduty-plugin/releases/download/v0.1.3/opennms-pagerduty-plugin.kar -P /opt/opennms/deploy/
+
+Extract the archive and verify the checksum
+```shell
+tar xzf opennms-pagerduty-plugin.tar.gz
+shasum -c shasum256.txt
+```
+
+Copy the kar file to your deploy folder
+```shell
+cp opennms-pagerduty-plugin-*.kar ${OPENNMS_HOME}/deploy
 ```
 
 Configure the plugin to be installed when OpenNMS starts:
-```
-echo 'opennms-plugins-pagerduty wait-for-kar=opennms-pagerduty-plugin' | sudo tee /opt/opennms/etc/featuresBoot.d/pagerduty.boot
+```shell
+echo 'opennms-plugins-pagerduty wait-for-kar=opennms-pagerduty-plugin' | sudo tee ${OPENNMS_HOME}/etc/featuresBoot.d/pagerduty.boot
 ```
 
 Access the [Karaf shell](https://opennms.discourse.group/t/karaf-cli-cheat-sheet/149) and install the feature manually to avoid having to restart:
-```
+```shell
 feature:install opennms-plugins-pagerduty
 ``` 
 
+## 👩‍🔧 Configuration
+
 Configure global options (affects all services for this instance):
-```
+```shell
 config:edit org.opennms.plugins.pagerduty
 property-set client OpenNMS
 property-set alarmDetailsUrlPattern 'http://"YOUR-OPENNMS-IP-ADDRESS"/opennms/alarm/detail.htm?id=%d'
 config:update
 ```
+
+> [!NOTE]
 > Use the IP address of your OpenNMS server (e.g., 127.0.0.1:8980).
 
 Configure services:
-```
+```shell
 config:edit --alias core --factory org.opennms.plugins.pagerduty.services
 property-set routingKey "YOUR-INTEGRATION-KEY-HERE"
 config:update
 ```
 
+> [!NOTE]
 > Use the value of the "Integration Key" as the `routingKey` in the service integrations. Use a JEXL expression to filter the types of notifcations you receive. For example,`property-set jexlFilter 'alarm.reductionKey =~ ".*trigger.*"'` will forward only alarms with the label "trigger" to PagerDuty. No alarms will forward to PagerDuty until a JEXL expression is configured.   
 
 The plugin supports handling multiple services simultaneously - use a different `alias` for each of these when configuring.
 
-### Alarm filtering
+## 🎚️ Alarm filtering
 
 We currently only support JEXL expressions for controlling which alarms get forwarded to a given service.
 
 You can use the `opennms-pagerduty:eval-jexl` command to help test expressions before committing them to configuration i.e.:
-```
+```shell
 admin@opennms> opennms-pagerduty:eval-jexl 'alarm.reductionKey =~ ".*trigger.*"'
 No alarms matched (out of 1 alarms.)
 admin@opennms> opennms-pagerduty:eval-jexl 'alarm.reductionKey =~ ".*"'
 MATCHED: ImmutableAlarm{reductionKey='uei.opennms.org/devjam/2020/minecraft/playerEnteredZone:mousebar:x_intercept', id=109, node=null, managedObjectInstance='null', managedObjectType='zone', type=null, severity=WARNING, attributes={}, relatedAlarms=[], logMessage='x_intercept has entered mousebar.', description='x_intercept has entered mousebar.', lastEventTime=2020-07-30 16:31:26.904, firstEventTime=2020-07-30 16:31:26.904, lastEvent=ImmutableDatabaseEvent{uei='uei.opennms.org/devjam/2020/minecraft/playerEnteredZone', id=195, parameters=[ImmutableEventParameter{name='zone', value='mousebar'}, ImmutableEventParameter{name='player', value='x_intercept'}]}, acknowledged=false}
 ```
 
-#### JEXL Expression Examples
+### JEXL Expression Examples
 
 The OpenNMS PagerDuty integration leverages [Apache Commons JEXL Syntax](https://commons.apache.org/proper/commons-jexl/reference/syntax.html) to allow filtering the alarms that get passed to PagerDuty.
 
 Each expression will have a single `alarm` variable set, which is an [Alarm](https://github.com/OpenNMS/opennms-integration-api/blob/master/api/src/main/java/org/opennms/integration/api/v1/model/Alarm.java) object with details about the alarm. If the expression evaluates to `true`, then a PagerDuty event is created for this alarm.
 
-##### All alarms for a nodes with "Test" and "Servers" categories assigned
+#### All alarms for a nodes with "Test" and "Servers" categories assigned
 
-```
+```shell
 admin@opennms> property-set jexlFilter '"Servers" =~ alarm.node.categories and "Test" =~ alarm.node.categories'
 ```
 
@@ -80,7 +97,7 @@ This leverages the `=~` operator to mean "'Servers' is in the alarm's node's cat
 
 #### Excluding some alarms from the above
 
-```
+```shell
 admin@opennms> property-set jexlFilter '"Servers" =~ alarm.node.categories and "Test" =~ alarm.node.categories and alarm.reductionKey !~ "^uei\.opennms\.org/generic/traps/SNMP_Authen_Failure:.*"'
 ```
 
@@ -88,7 +105,7 @@ This leverages the `!~` operator to mean "the alarm reduction key does not match
 
 #### Only Alarms That Can Auto-Resolve
 
-```
+```shell
 admin@opennms> property-set jexlFilter '"Servers" =~ alarm.node.categories and "Test" =~ alarm.node.categories and alarm.type.name == "PROBLEM"'
 ```
 
@@ -96,7 +113,7 @@ This limits to only alarms for certain categories of nodes that have a resolutio
 
 ### Hold-Down Timer (Delayed Notifications)
 
-Some alarms may quick resolve themselves, especially occasional brief outages from the OpenNMS service pollers.
+Some alarms may quickly resolve themselves, especially occasional brief outages from the OpenNMS service pollers.
 
 To be able to get the full benefits of the OpenNMS [Downtime Model](https://docs.opennms.org/opennms/releases/latest/guide-admin/guide-admin.html#ga-service-assurance-downtime-model),
 you can specify a hold-down timer of at least a few minutes, to trade off instant notification of issues for
@@ -106,7 +123,7 @@ Similar to configuring the `jexlFilter` above, you can edit a specific service's
 the specific configuration to edit, use `config:list` as shown below, then use `config:edit` to edit the Pid of that specific
 service's configuration:
 
-```
+```shell
 admin@opennms> config:list '(service.factoryPid=org.opennms.plugins.pagerduty.services)'
 ----------------------------------------------------------------
 Pid:            org.opennms.plugins.pagerduty.services.bbc99bb4-bc56-4d56-b35c-14066b6e2dcf
@@ -131,34 +148,36 @@ by [`java.time.Duration.parse()`](https://docs.oracle.com/javase/8/docs/api/java
 In cases where forwarding an alarm to PagerDuty fails, the plugin will generate a `uei.opennms.org/pagerduty/sendEventFailed` locally that will trigger an alarm.
 The event contains details on the error that occurred. You could use it to trigger alternate notification mechanisms.
 
-## Developing
+## 👩‍🔬 Developing
 
 Build and install the plugin into your local Maven repository using:
+```shell
+make
 ```
-mvn clean install
-```
-
-> OpenNMS normally runs as root, so make sure the artifacts are installed in `/root/.m2` or try making `/root/.m2` symlink to your user's repository
+> [!TIP]
+> OpenNMS normally runs as root, so make sure the artifacts are installed in `/root/.m2` or try making `/root/.m2` symlink to your user's repository.
+> The kar file is created in the `assembly/kar/target` directory.
 
 From the OpenNMS Karaf shell:
-```
-feature:repo-add mvn:org.opennms.plugins/pagerduty-karaf-features/1.0.0-SNAPSHOT/xml
+```shell
+feature:repo-add mvn:org.opennms.plugins/pagerduty-karaf-features/<MAVEN-POM-VERSION>/xml
 feature:install opennms-plugins-pagerduty
 ```
+> [!NOTE]
+> Replace <MAVEN-POM-VERSION> with the version number from the pom.xml in your current working branch.
 
 Update automatically:
-```
+```shell
 bundle:watch *
 ```
 
 ### Debugging
 
 Add the following lines to `$OPENNMS_HOME/etc/org.ops4j.pax.logging.cfg`:
-```
+```shell
 # PagerDuty plugin
 log4j2.logger.pd-plugin.name = org.opennms.integrations.pagerduty
 log4j2.logger.pd-plugin.level = DEBUG
 log4j2.logger.pd-client.name = org.opennms.pagerduty
 log4j2.logger.pd-client.level = DEBUG
 ```
-

--- a/assembly/kar/pom.xml
+++ b/assembly/kar/pom.xml
@@ -24,7 +24,7 @@
                         </goals>
                         <configuration>
                             <featuresFile>mvn:org.opennms.plugins/pagerduty-karaf-features/${project.version}/xml</featuresFile>
-                            <finalName>opennms-pagerduty-plugin</finalName>
+                            <finalName>opennms-pagerduty-plugin-${project.version}</finalName>
                             <ignoreDependencyFlag>true</ignoreDependencyFlag>
                             <archive>
                               <manifestEntries>


### PR DESCRIPTION
Allow a developer to build and release the project easily. Added a goal to run a `make release RELEASE_VERSION=x.y.z` which deals with all the Maven versioning and version tags to prepare a release.

Improved the README and some cleanup.

## Reviewer Hint

The CI/CD needs to be enhanced to:

* Create job triggered on pushing a git version tag `v*`
* Create a task to create GitHub release in the GitHub repository from CircleCI
* Upload the ~/artifacts assets to the release
